### PR TITLE
Bugfix: application fetched are always in default state

### DIFF
--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -342,14 +342,16 @@ contract ApplicationRegistry is Ownable,Pausable,IApplicationRegistry {
     function fetchMyApplications() external view returns(Application[] memory,string[] memory,string[] memory){
         string[] memory grantMetaDataHash = new string[](creatorApplicationMap[msg.sender].length);
         string[] memory workspaceDataHash = new string[](creatorApplicationMap[msg.sender].length);
+        Application[] memory _applications = new Application[](creatorApplicationMap[msg.sender].length);
 
         for(uint256 i = 0;i < creatorApplicationMap[msg.sender].length;i++){
             string memory workspaceHash = workspaceReg.getMetaDataHash(creatorApplicationMap[msg.sender][i].workspaceId);
             workspaceDataHash[i] = workspaceHash;
             string memory grantHash = IGrants(creatorApplicationMap[msg.sender][i].grantAddress).getMetadataHash();
             grantMetaDataHash[i] = grantHash;
+            _applications[i] = applications[creatorApplicationMap[msg.sender][i].id];
         }  
-        return (creatorApplicationMap[msg.sender],grantMetaDataHash,workspaceDataHash);
+        return (_applications,grantMetaDataHash,workspaceDataHash);
     }
     
 }


### PR DESCRIPTION
Task: https://app.clickup.com/t/85zrh9zg7

For some reason `creatorApplicationMap` was not storing application with updated states. Updated the function to return applications from `applications` state variable.