### PR TITLE
add milestone approval revert support

### DIFF
--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -341,6 +341,8 @@ contract ApplicationRegistry is Ownable,Pausable,IApplicationRegistry {
     }
 
     function updateMilestoneStateGrant(uint256 _applicationId, uint256 _milestoneId, MilestoneState _state) external override onlyParentGrant(_applicationId)  {
+        if (applicationMilestones[_applicationId][_milestoneId].state == _state) return;
+        if (applicationMilestones[_applicationId][_milestoneId].state == MilestoneState.ApprovePending) applications[_applicationId].milestonesDone -= 1;
         applicationMilestones[_applicationId][_milestoneId].state = _state;
     }
 

--- a/contracts/Grants.sol
+++ b/contracts/Grants.sol
@@ -197,6 +197,8 @@ contract Grant is Ownable,Pausable,IGrants{
     event queuedTransaction(address grantAddress,uint256 amount,uint256 time,address to,uint256 applicationId);
     event executeTransaction(address grantAddress,uint256 amount,uint256 time,address to,uint256 applicationId);
     event revertTransaction(address grantAddress,uint256 amount,uint256 time,address to,uint256 applicationId);
+    event revertMilestoneTransaction(address grantAddress,uint256 amount,uint256 time,address to,uint256 applicationId, uint256 milestoneId);
+
 
     constructor(
         uint256 _workspaceId,
@@ -328,8 +330,28 @@ contract Grant is Ownable,Pausable,IGrants{
                 if(pendingPayments[i].applicationId == applicationId){
                     IApplicationRegistry(applicationReg).updateApplicationStateGrant(applicationId, ApplicationRegistry.ApplicationState.Rejected);
                     promisedAmount -= pendingPayments[i].amountPay;
-                    
+
                     emit revertTransaction(address(this),pendingPayments[i].amountPay , block.timestamp, pendingPayments[i].to,applicationId);
+                    pendingPayments[i] = pendingPayments[pendingPayments.length-1];
+                    pendingPayments.pop();
+                    break;
+                }
+
+            }
+        }
+        else revert("Not Authorized : RevertTransaction");
+    }
+
+    function revertMilestoneTransactions(uint256 applicationId, uint milestoneId) external { 
+        if(this.isGrantAdminOrReviewer(msg.sender)){
+
+            for(uint256 i = 0;i < pendingPayments.length;i++){
+                if (!pendingPayments[i].isMilestone) continue;
+                if(pendingPayments[i].applicationId == applicationId && pendingPayments[i].milestoneId == milestoneId){
+                    IApplicationRegistry(applicationReg).updateMilestoneStateGrant(applicationId, milestoneId, ApplicationRegistry.MilestoneState.Requested);
+                    promisedAmount -= pendingPayments[i].amountPay;
+
+                    emit revertMilestoneTransaction(address(this), pendingPayments[i].amountPay, block.timestamp, pendingPayments[i].to, applicationId, milestoneId);
                     pendingPayments[i] = pendingPayments[pendingPayments.length-1];
                     pendingPayments.pop();
                     break;

--- a/contracts/Grants.sol
+++ b/contracts/Grants.sol
@@ -342,7 +342,7 @@ contract Grant is Ownable,Pausable,IGrants{
         else revert("Not Authorized : RevertTransaction");
     }
 
-    function revertMilestoneTransactions(uint256 applicationId, uint milestoneId) external { 
+    function revertMilestoneTransactions(uint256 applicationId, uint256 milestoneId) external { 
         if(this.isGrantAdminOrReviewer(msg.sender)){
 
             for(uint256 i = 0;i < pendingPayments.length;i++){


### PR DESCRIPTION
Needed a function call to revert milestone approval. Current, `Grant.revertTransaction` function was not precise enough for milestones.